### PR TITLE
Add link to my blog post on learning the kana

### DIFF
--- a/lang/ja/kana/README.md
+++ b/lang/ja/kana/README.md
@@ -1,8 +1,8 @@
 # Japanese Kana trainer
 
 This tool will help you practice your knowledge of
-[Hiragana](https://en.wikipedia.org/wiki/Hiragana) and
-[Katakana](https://en.wikipedia.org/wiki/Katakana).
+[hiragana](https://en.wikipedia.org/wiki/Hiragana) and
+[katakana](https://en.wikipedia.org/wiki/Katakana).
 
 To start the practice session, you may use any of the following methods:
 
@@ -11,10 +11,12 @@ To start the practice session, you may use any of the following methods:
 * run `open.sh` from the command line (which will open a browser for you with
   the same file)
 
-Note that it will not _teach_ you Hiragana or Katakana; to learn, you may use a
-book such as [_Remembering the
-Kana_](https://en.wikipedia.org/wiki/Remembering_the_Kanji_and_Remembering_the_Hanzi#Remembering_the_Kana)
-by James Heisig, a website, or an app.
+Note that it will not _teach_ you hiragana or katakana; to learn, you may use a
+book such as _Remembering the Kana_ by James Heisig, or the websites and mobile
+apps mentioned below.
+
+For an overview of hiragana and katanana and how I learned them, see [my blog
+post][my-blog-post].
 
 ## Related work
 
@@ -26,3 +28,6 @@ Similar projects on the web:
 Related mobile apps:
 
 * [Kanji Study](https://play.google.com/store/apps/details?id=com.mindtwisted.kanjistudy) for Android
+
+
+[my-blog-post]: https://misha.brukman.net/blog/2020/01/learning-japanese-hiragana-and-katakana/


### PR DESCRIPTION
* remove the link to _Remembering the Kana_ on Wikipedia as it's not a
  useful pointer; my blog has links to a book preview whcih is more
  useful, but needs to be provided in context
* lowercase hiragana and katakana